### PR TITLE
Adiciona link no texto

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,9 +120,9 @@
 
                             Tenho me dedicado também a aprender e desenvolver minhas habilidades em aplicações Web.
 
-                            Você pode conferir meus projetos e informações sobre o que venho estudando no meu Github:
+                            Você pode conferir meus projetos e informações sobre o que venho estudando no meu <a href="https://github.com/Ursulinocosta" target="_blank" class="styled-link">Github</a>
 
-                            https://github.com/Ursulinocosta. <br><br><br>
+                            <br><br><br>
                         </p>
                         <div class="btn-social">
                             <a href="#"><button><i class="bi bi-instagram"></i></button></a>

--- a/style.css
+++ b/style.css
@@ -230,14 +230,14 @@ section.sobre .flex {
 }
 
 .sobre .styled-link{
-  color: black;
-  text-decoration: none;
-  border-bottom: 1px solid rgb(50, 131, 207);
-  transition: all 400ms;
+    color: black;
+    text-decoration: none;
+    border-bottom: 1px solid rgb(50, 131, 207);
+    transition: all 400ms;
 }
 
 .sobre .styled-link:hover{
-  border-bottom: 2px solid rgb(50, 131, 207);
+    border-bottom: 2px solid rgb(50, 131, 207);
 }
 
 

--- a/style.css
+++ b/style.css
@@ -233,6 +233,11 @@ section.sobre .flex {
   color: black;
   text-decoration: none;
   border-bottom: 1px solid rgb(50, 131, 207);
+  transition: all 400ms;
+}
+
+.sobre .styled-link:hover{
+  border-bottom: 2px solid rgb(50, 131, 207);
 }
 
 

--- a/style.css
+++ b/style.css
@@ -229,6 +229,12 @@ section.sobre .flex {
 
 }
 
+.sobre .styled-link{
+  color: black;
+  text-decoration: none;
+  border-bottom: 1px solid rgb(50, 131, 207);
+}
+
 
 .btn-social button {
     width: 60px;


### PR DESCRIPTION
SOBRE:

O projeto ta top meu mano, parabéns

CASO:

enquanto navegava pelo site percebir que no texto da seção sobre havia um link que não estava dentro de uma tag ai ele não estava pegando.

SOLUÇÃO:

adcionei o link dentro de uma tag que passou a exibir o link de uma forma discreta porem com um certo destaque.

COMO FICOU:
![image](https://github.com/Ursulinocosta/linnuxz.dev/assets/63233782/5c18fb66-fba4-4c1e-9bdd-1147b66627a5)
